### PR TITLE
Add conditional to prevent skipping GUIDs

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,13 @@ Examples:\
 `./bin/sync.sh prod example.com media down`\
 `./bin/sync.sh prod example.com all up`
 
+## Skipping GUIDs
+
+Skipping the GUID column is the default behaviour as it can have unwanted effects on production environments. If you are sure you want to replace GUID URLs, for example if you are deploying a site to production for the first time, you can prevent skipping GUIDs with `--extra-vars "skip_guids=false"`.
+
+Example:\
+`./bin/sync.sh prod example.com db up --extra-vars "skip_guids=false"`
+
 ## Notes
 * Tested up to Ansible 2.6.1
 * Replace Elementor urls on database sync (if installed).

--- a/database.yml
+++ b/database.yml
@@ -14,6 +14,8 @@
     domain_env: "{{ project.site_hosts.0.canonical }}"
     url_dev: "{{ hostvars[dev_host].wordpress_sites[site].ssl.enabled | ternary('https', 'http') }}://{{ domain_dev }}"
     url_env: "{{ project.ssl.enabled | ternary('https', 'http') }}://{{ domain_env }}"
+    skip_guids_option: "--skip-columns=guid"
+    skip_guids_column: "{{ skip_guids | default('true') }}"
 
   tasks:
     - name: Abort if environment variable is equal to development
@@ -23,6 +25,11 @@
 
     # PULL database
     - block:
+      - name: Modify GUID columns
+        set_fact:
+          skip_guids_option: ""
+        when: "skip_guids_column == 'false'"
+
       - name: PULL > Export & gzip {{ env }} database
         shell: 'wp db export {{ sync_file }} --skip-plugins --skip-themes && gzip -q {{ sync_file }}'
         args:
@@ -59,11 +66,11 @@
 
       - name: PULL > Replace urls "{{ url_env }}" => "{{ url_dev }}" on development
         connection: local
-        shell: vagrant ssh -- "cd {{ project_current }} && wp search-replace '{{ url_env }}' '{{ url_dev }}' --all-tables --skip-plugins --skip-themes"
+        shell: vagrant ssh -- "cd {{ project_current }} && wp search-replace '{{ url_env }}' '{{ url_dev }}' {{ skip_guids_option }} --all-tables --skip-plugins --skip-themes"
 
       - name: PULL > Replace protocol-relative urls "//{{ domain_env }}" => "//{{ domain_dev }}" on development
         connection: local
-        shell: vagrant ssh -- "cd {{ project_current }} && wp search-replace '//{{ domain_env }}' '//{{ domain_dev }}' --all-tables --skip-plugins --skip-themes"
+        shell: vagrant ssh -- "cd {{ project_current }} && wp search-replace '//{{ domain_env }}' '//{{ domain_dev }}' {{ skip_guids_option }} --all-tables --skip-plugins --skip-themes"
 
       - name: PULL > Replace emails "@{{ domain_env }}" => "@{{ domain_dev }}" on development
         connection: local
@@ -117,12 +124,12 @@
           path: "{{ project_current }}/{{ sync_file }}"
 
       - name: PUSH > Replace urls "{{ url_dev }}" => "{{ url_env }}" on {{ env }}
-        command: wp search-replace '{{ url_dev }}' '{{ url_env }}' --all-tables --skip-plugins --skip-themes
+        command: wp search-replace '{{ url_dev }}' '{{ url_env }}' {{ skip_guids_option }} --all-tables --skip-plugins --skip-themes
         args:
           chdir: "{{ project_current }}"
 
       - name: PUSH > Replace protocol-relative urls "//{{ domain_dev }}" => "//{{ domain_env }}" on {{ env }}
-        command: wp search-replace '//{{ domain_dev }}' '//{{ domain_env }}' --all-tables --skip-plugins --skip-themes
+        command: wp search-replace '//{{ domain_dev }}' '//{{ domain_env }}' {{ skip_guids_option }} --all-tables --skip-plugins --skip-themes
         args:
           chdir: "{{ project_current }}"
 

--- a/database.yml
+++ b/database.yml
@@ -15,7 +15,7 @@
     url_dev: "{{ hostvars[dev_host].wordpress_sites[site].ssl.enabled | ternary('https', 'http') }}://{{ domain_dev }}"
     url_env: "{{ project.ssl.enabled | ternary('https', 'http') }}://{{ domain_env }}"
     skip_guids_option: "--skip-columns=guid"
-    skip_guids_column: "{{ skip_guids | default('true') }}"
+    skip_guids_column: "{{ skip_guids | default('false') }}"
 
   tasks:
     - name: Abort if environment variable is equal to development


### PR DESCRIPTION
If skip_guid is passed as false, GUIDs will not be skipped

Usage:
sync.sh <environment> <site> db <push|pull> --extra-vars "skip_guids=false"

Fixes #8 and #7 
Replaces #6 